### PR TITLE
Fixed issues preventing compilation under MSVC

### DIFF
--- a/capture.c
+++ b/capture.c
@@ -1103,7 +1103,7 @@ static HRESULT WINAPI DSCImpl_Initialize(IDirectSoundCapture *iface, const GUID 
             IsEqualGUID(devguid, &DSDEVID_DefaultVoicePlayback))
         return DSERR_NODRIVER;
 
-    hr = GetDeviceID(devguid, &guid);
+    hr = DSOAL_GetDeviceID(devguid, &guid);
     if(FAILED(hr)) return hr;
 
     devguid = &guid;

--- a/dsound.def
+++ b/dsound.def
@@ -1,15 +1,15 @@
 LIBRARY DSOUND.dll
 
 EXPORTS
-    DirectSoundCreate               = DirectSoundCreate@12              @1
-    DirectSoundEnumerateA           = DirectSoundEnumerateA@8           @2
-    DirectSoundEnumerateW           = DirectSoundEnumerateW@8           @3
-    DirectSoundCaptureCreate        = DirectSoundCaptureCreate@12       @6
-    DirectSoundCaptureEnumerateA    = DirectSoundCaptureEnumerateA@8    @7
-    DirectSoundCaptureEnumerateW    = DirectSoundCaptureEnumerateW@8    @8
-    GetDeviceID                     = GetDeviceID@8                     @9
-    DirectSoundFullDuplexCreate     = DirectSoundFullDuplexCreate@40    @10
-    DirectSoundCreate8              = DirectSoundCreate8@12             @11
-    DirectSoundCaptureCreate8       = DirectSoundCaptureCreate8@12      @12
-    DllCanUnloadNow                 = DllCanUnloadNow@0                 @4 PRIVATE
-    DllGetClassObject               = DllGetClassObject@12              @5 PRIVATE
+    DirectSoundCreate               = _DSOAL_DirectSoundCreate@12				@1
+    DirectSoundEnumerateA           = _DSOAL_DirectSoundEnumerateA@8			@2
+    DirectSoundEnumerateW           = _DSOAL_DirectSoundEnumerateW@8			@3
+    DirectSoundCaptureCreate        = _DSOAL_DirectSoundCaptureCreate@12		@4
+    DirectSoundCaptureEnumerateA    = _DSOAL_DirectSoundCaptureEnumerateA@8		@5
+    DirectSoundCaptureEnumerateW    = _DSOAL_DirectSoundCaptureEnumerateW@8		@6
+    GetDeviceID                     = _DSOAL_GetDeviceID@8						@7
+    DirectSoundFullDuplexCreate     = _DSOAL_DirectSoundFullDuplexCreate@40		@8
+    DirectSoundCreate8              = _DSOAL_DirectSoundCreate8@12				@9
+    DirectSoundCaptureCreate8       = _DSOAL_DirectSoundCaptureCreate8@12		@10
+    DllCanUnloadNow                 = _DSOAL_DllCanUnloadNow@0							PRIVATE
+    DllGetClassObject               = _DSOAL_DllGetClassObject@12						PRIVATE

--- a/dsound8.c
+++ b/dsound8.c
@@ -1052,7 +1052,7 @@ static HRESULT WINAPI DS8_Initialize(IDirectSound8 *iface, const GUID *devguid)
             IsEqualGUID(devguid, &DSDEVID_DefaultVoiceCapture))
         return DSERR_NODRIVER;
 
-    hr = GetDeviceID(devguid, &guid);
+    hr = DSOAL_GetDeviceID(devguid, &guid);
     if(FAILED(hr)) return hr;
 
     EnterCriticalSection(&openal_crst);

--- a/dsound_main.c
+++ b/dsound_main.c
@@ -474,6 +474,20 @@ static const char *get_device_id(LPCGUID pGuid)
     return debugstr_guid(pGuid);
 }
 
+const CLSID CLSID_MMDeviceEnumerator = {
+	0xBCDE0395,
+	0xE52F,
+	0x467C,
+	0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E
+};
+
+const IID IID_IMMDeviceEnumerator = {
+	0xA95664D2,
+	0x9614,
+	0x4F35,
+	0xA7, 0x46, 0xDE, 0x8D, 0xB6, 0x36, 0x17, 0xE6
+};
+
 static HRESULT get_mmdevenum(IMMDeviceEnumerator **devenum)
 {
     HRESULT hr, init_hr;
@@ -749,7 +763,7 @@ HRESULT enumerate_mmdevices(EDataFlow flow, PRVTENUMCALLBACK cb, void *user)
  *    Returns pGuidSrc if pGuidSrc is a valid device or the device
  *    GUID for the specified constants.
  */
-DECLSPEC_EXPORT HRESULT WINAPI GetDeviceID(LPCGUID pGuidSrc, LPGUID pGuidDest)
+HRESULT WINAPI DSOAL_GetDeviceID(LPCGUID pGuidSrc, LPGUID pGuidDest)
 {
     IMMDeviceEnumerator *devenum;
     HRESULT hr, init_hr;
@@ -857,7 +871,7 @@ static BOOL CALLBACK w_to_a_callback(EDataFlow flow, LPGUID guid, LPCWSTR descW,
  *    Success: DS_OK
  *    Failure: DSERR_INVALIDPARAM
  */
-DECLSPEC_EXPORT HRESULT WINAPI DirectSoundEnumerateA(
+HRESULT WINAPI DSOAL_DirectSoundEnumerateA(
     LPDSENUMCALLBACKA lpDSEnumCallback,
     LPVOID lpContext)
 {
@@ -893,7 +907,7 @@ DECLSPEC_EXPORT HRESULT WINAPI DirectSoundEnumerateA(
  *    Success: DS_OK
  *    Failure: DSERR_INVALIDPARAM
  */
-DECLSPEC_EXPORT HRESULT WINAPI DirectSoundEnumerateW(
+HRESULT WINAPI DSOAL_DirectSoundEnumerateW(
     LPDSENUMCALLBACKW lpDSEnumCallback,
     LPVOID lpContext )
 {
@@ -928,7 +942,7 @@ DECLSPEC_EXPORT HRESULT WINAPI DirectSoundEnumerateW(
  *    Success: DS_OK
  *    Failure: DSERR_INVALIDPARAM
  */
-DECLSPEC_EXPORT HRESULT WINAPI DirectSoundCaptureEnumerateA(
+HRESULT WINAPI DSOAL_DirectSoundCaptureEnumerateA(
     LPDSENUMCALLBACKA lpDSEnumCallback,
     LPVOID lpContext)
 {
@@ -963,7 +977,7 @@ DECLSPEC_EXPORT HRESULT WINAPI DirectSoundCaptureEnumerateA(
  *    Success: DS_OK
  *    Failure: DSERR_INVALIDPARAM
  */
-DECLSPEC_EXPORT HRESULT WINAPI DirectSoundCaptureEnumerateW(
+HRESULT WINAPI DSOAL_DirectSoundCaptureEnumerateW(
     LPDSENUMCALLBACKW lpDSEnumCallback,
     LPVOID lpContext)
 {
@@ -1000,8 +1014,8 @@ DECLSPEC_EXPORT HRESULT WINAPI DirectSoundCaptureEnumerateW(
  *     Failure: DSERR_ALLOCATED, DSERR_INVALIDPARAM, DSERR_NOAGGREGATION,
  *              DSERR_NODRIVER, DSERR_OUTOFMEMORY
  */
-DECLSPEC_EXPORT HRESULT WINAPI
-DirectSoundCreate(LPCGUID lpcGUID, IDirectSound **ppDS, IUnknown *pUnkOuter)
+HRESULT WINAPI
+DSOAL_DirectSoundCreate(LPCGUID lpcGUID, IDirectSound **ppDS, IUnknown *pUnkOuter)
 {
     HRESULT hr;
     void *pDS;
@@ -1049,8 +1063,8 @@ DirectSoundCreate(LPCGUID lpcGUID, IDirectSound **ppDS, IUnknown *pUnkOuter)
  *     Failure: DSERR_ALLOCATED, DSERR_INVALIDPARAM, DSERR_NOAGGREGATION,
  *              DSERR_NODRIVER, DSERR_OUTOFMEMORY
  */
-DECLSPEC_EXPORT HRESULT WINAPI
-DirectSoundCreate8(LPCGUID lpcGUID, IDirectSound8 **ppDS, IUnknown *pUnkOuter)
+HRESULT WINAPI
+DSOAL_DirectSoundCreate8(LPCGUID lpcGUID, IDirectSound8 **ppDS, IUnknown *pUnkOuter)
 {
     HRESULT hr;
     void *pDS;
@@ -1105,8 +1119,8 @@ DirectSoundCreate8(LPCGUID lpcGUID, IDirectSound8 **ppDS, IUnknown *pUnkOuter)
  *
  *    DSERR_ALLOCATED is returned for sound devices that do not support full duplex.
  */
-DECLSPEC_EXPORT HRESULT WINAPI
-DirectSoundCaptureCreate(LPCGUID lpcGUID, IDirectSoundCapture **ppDSC, IUnknown *pUnkOuter)
+HRESULT WINAPI
+DSOAL_DirectSoundCaptureCreate(LPCGUID lpcGUID, IDirectSoundCapture **ppDSC, IUnknown *pUnkOuter)
 {
     HRESULT hr;
     void *pDSC;
@@ -1163,8 +1177,8 @@ DirectSoundCaptureCreate(LPCGUID lpcGUID, IDirectSoundCapture **ppDSC, IUnknown 
  *
  *    DSERR_ALLOCATED is returned for sound devices that do not support full duplex.
  */
-DECLSPEC_EXPORT HRESULT WINAPI
-DirectSoundCaptureCreate8(LPCGUID lpcGUID, IDirectSoundCapture8 **ppDSC8, IUnknown *pUnkOuter)
+HRESULT WINAPI
+DSOAL_DirectSoundCaptureCreate8(LPCGUID lpcGUID, IDirectSoundCapture8 **ppDSC8, IUnknown *pUnkOuter)
 {
     HRESULT hr;
     void *pDSC8;
@@ -1313,7 +1327,7 @@ static IClassFactoryImpl DSOUND_CF[] = {
  *    Failure: CLASS_E_CLASSNOTAVAILABLE, E_OUTOFMEMORY, E_INVALIDARG,
  *             E_UNEXPECTED
  */
-DECLSPEC_EXPORT HRESULT WINAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv)
+HRESULT WINAPI DSOAL_DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID *ppv)
 {
     int i = 0;
     TRACE("(%s, %s, %p)\n", debugstr_guid(rclsid), debugstr_guid(riid), ppv);
@@ -1353,7 +1367,7 @@ DECLSPEC_EXPORT HRESULT WINAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, L
  *    Success: S_OK
  *    Failure: S_FALSE
  */
-DECLSPEC_EXPORT HRESULT WINAPI DllCanUnloadNow(void)
+HRESULT WINAPI DSOAL_DllCanUnloadNow(void)
 {
     FIXME("(void): stub\n");
     return S_FALSE;

--- a/dsound_private.h
+++ b/dsound_private.h
@@ -909,3 +909,13 @@ HRESULT enumerate_mmdevices(EDataFlow flow, PRVTENUMCALLBACK cb, void *user);
 HRESULT get_mmdevice(EDataFlow flow, const GUID *tgt, IMMDevice **device);
 
 extern const WCHAR aldriver_name[];
+
+#ifndef DECLSPEC_EXPORT
+#ifdef _WIN32
+#define DECLSPEC_EXPORT __declspec(dllexport)
+#else
+#define DECLSPEC_EXPORT
+#endif
+#endif
+
+HRESULT WINAPI DSOAL_GetDeviceID(LPCGUID pGuidSrc, LPGUID pGuidDest);

--- a/duplex.c
+++ b/duplex.c
@@ -538,7 +538,7 @@ HRESULT DSOUND_FullDuplexCreate(
  *             DSERR_OUTOFMEMORY DSERR_INVALIDCALL DSERR_NODRIVER
  */
 HRESULT WINAPI
-DirectSoundFullDuplexCreate(
+DSOAL_DirectSoundFullDuplexCreate(
     LPCGUID pcGuidCaptureDevice, LPCGUID pcGuidRenderDevice,
     LPCDSCBUFFERDESC pcDSCBufferDesc, LPCDSBUFFERDESC pcDSBufferDesc,
     HWND hWnd, DWORD dwLevel,

--- a/propset.c
+++ b/propset.c
@@ -225,7 +225,7 @@ static HRESULT DSPROPERTY_DescriptionW(
         }
     }
 
-    GetDeviceID(&ppd->DeviceId, &dev_guid);
+    DSOAL_GetDeviceID(&ppd->DeviceId, &dev_guid);
 
     hr = get_mmdevice(eRender, &dev_guid, &mmdevice);
     if(FAILED(hr)){


### PR DESCRIPTION
MSVC was having trouble compiling dsoal due to identical identifiers causing ODR violations and missing definitions for _CLSID_MMDeviceEnumerator_ and _IID_IMMDeviceEnumerator_.

Tested against Visual Studio 2017.