### PR TITLE
Initial implementation of DSPROPSETID_VoiceManager.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,8 @@ set(DSOAL_OBJS buffer.c
                eax-presets.h
                primary.c
                propset.c
-               reverb.c)
+               reverb.c
+               voiceman.c)
 
 set(DSOAL_INC ${DSOAL_INC} ${DSOAL_BINARY_DIR} ${DSOAL_SOURCE_DIR}/include/AL)
 

--- a/buffer.c
+++ b/buffer.c
@@ -587,7 +587,9 @@ HRESULT DSBuffer_Create(DSBuffer **ppv, DSPrimary *prim, IDirectSoundBuffer *ori
     for(i = 0;i < EAX_MAX_FXSLOTS;++i)
         This->deferred.send[i] = This->current.send[i];
     This->deferred.eax1_reverbmix = This->current.eax1_reverbmix;
-
+    
+    This->vm_voicepriority = (DWORD)-1;
+    
     *ppv = This;
     return DS_OK;
 }
@@ -2827,6 +2829,8 @@ static HRESULT WINAPI DSBufferProp_Get(IKsPropertySet *iface,
         hr = EAX1Buffer_Get(This, dwPropID, pPropData, cbPropData, pcbReturned);
     else if(IsEqualIID(guidPropSet, &DSPROPSETID_EAX10_ListenerProperties))
         hr = EAX1_Get(This->primary, dwPropID, pPropData, cbPropData, pcbReturned);
+    else if(IsEqualIID(guidPropSet, &DSPROPSETID_VoiceManager))
+        hr = VoiceMan_Get(This, dwPropID, pPropData, cbPropData, pcbReturned);
     else
         FIXME("Unhandled propset: %s\n", debug_bufferprop(guidPropSet));
     LeaveCriticalSection(&This->share->crst);
@@ -2972,6 +2976,10 @@ static HRESULT WINAPI DSBufferProp_Set(IKsPropertySet *iface,
             DSPrimary3D_CommitDeferredSettings(&prim->IDirectSound3DListener_iface);
         popALContext();
     }
+    else if(IsEqualIID(guidPropSet, &DSPROPSETID_VoiceManager))
+    {
+        hr = VoiceMan_Set(This, dwPropID, pPropData, cbPropData);
+    }
     else
         FIXME("Unhandled propset: %s\n", debug_bufferprop(guidPropSet));
     LeaveCriticalSection(&This->share->crst);
@@ -3018,6 +3026,8 @@ static HRESULT WINAPI DSBufferProp_QuerySupport(IKsPropertySet *iface,
         hr = EAX1_Query(This->primary, dwPropID, pTypeSupport);
     else if(IsEqualIID(guidPropSet, &DSPROPSETID_EAX10_BufferProperties))
         hr = EAX1Buffer_Query(This, dwPropID, pTypeSupport);
+    else if(IsEqualIID(guidPropSet, &DSPROPSETID_VoiceManager))
+        hr = VoiceMan_Query(This, dwPropID, pTypeSupport);
     else
         FIXME("Unhandled propset: %s (propid: %lu)\n", debug_bufferprop(guidPropSet), dwPropID);
     LeaveCriticalSection(&This->share->crst);

--- a/dsound8.c
+++ b/dsound8.c
@@ -211,6 +211,7 @@ static HRESULT DSShare_Create(REFIID guid, DeviceShare **out)
     share->ref = 1;
     share->refresh = FAKE_REFRESH_COUNT;
     share->speaker_config = DSSPEAKER_7POINT1_SURROUND;
+    share->vm_managermode = DSPROPERTY_VMANAGER_MODE_DEFAULT;
 
     TRACE("Creating shared device %p\n", share);
 

--- a/dsound_private.h
+++ b/dsound_private.h
@@ -435,6 +435,30 @@ extern LPALFLUSHMAPPEDBUFFERSOFT palFlushMappedBufferSOFT;
 #define E_PROP_ID_UNSUPPORTED           ((HRESULT)0x80070490)
 #endif
 
+typedef enum {
+    DSPROPERTY_VMANAGER_MODE = 0,
+    DSPROPERTY_VMANAGER_PRIORITY,
+    DSPROPERTY_VMANAGER_STATE
+} DSPROPERTY_VMANAGER;
+
+
+typedef enum {
+    DSPROPERTY_VMANAGER_MODE_DEFAULT = 0,
+    DSPROPERTY_VMANAGER_MODE_AUTO,
+    DSPROPERTY_VMANAGER_MODE_REPORT,
+    DSPROPERTY_VMANAGER_MODE_USER,
+    VMANAGER_MODE_MAX
+} VmMode;
+
+
+typedef enum {
+    DSPROPERTY_VMANAGER_STATE_PLAYING3DHW = 0,
+    DSPROPERTY_VMANAGER_STATE_SILENT,
+    DSPROPERTY_VMANAGER_STATE_BUMPED,
+    DSPROPERTY_VMANAGER_STATE_PLAYFAILED,
+    VMANAGER_STATE_MAX
+} VmState;
+
 /* OpenAL only allows for 1 single access to the device at the same time */
 extern CRITICAL_SECTION openal_crst;
 
@@ -514,6 +538,8 @@ typedef struct DeviceShare {
 
     GUID guid;
     DWORD speaker_config;
+    
+    DWORD vm_managermode;
 } DeviceShare;
 
 #define HAS_EXTENSION(s, e) BITFIELD_TEST((s)->Exts, e)
@@ -640,6 +666,9 @@ struct DSBuffer {
 
     DWORD nnotify, lastpos;
     DSBPOSITIONNOTIFY *notify;
+    
+    DWORD vm_voicepriority;
+    //DWORD vm_voicestate;
 };
 
 
@@ -781,10 +810,11 @@ DEFINE_GUID(KSDATAFORMAT_SUBTYPE_IEEE_FLOAT, 0x00000003, 0x0000, 0x0010, 0x80, 0
 
 DEFINE_DEVPROPKEY(DEVPKEY_Device_FriendlyName, 0xa45c254e,0xdf1c,0x4efd,0x80,0x20,0x67,0xd1,0x46,0xa8,0x50,0xe0, 14);
 
-DEFINE_GUID(DSPROPSETID_VoiceManager, 0x62a69bae, 0xdf9d, 0x11d1, 0x99, 0xa6, 0x00, 0xc0, 0x4f, 0xc9, 0x9d, 0x46);
 DEFINE_GUID(DSPROPSETID_ZOOMFX_BufferProperties, 0xcd5368e0, 0x3450, 0x11d3, 0x8b, 0x6e, 0x00, 0x10, 0x5a, 0x9b, 0x7b, 0xbc);
 DEFINE_GUID(DSPROPSETID_I3DL2_ListenerProperties, 0xda0f0520, 0x300a, 0x11d3, 0x8a, 0x2b, 0x00, 0x60, 0x97, 0x0d, 0xb0, 0x11);
 DEFINE_GUID(DSPROPSETID_I3DL2_BufferProperties,   0xda0f0521, 0x300a, 0x11d3, 0x8a, 0x2b, 0x00, 0x60, 0x97, 0x0d, 0xb0, 0x11);
+
+DEFINE_GUID(DSPROPSETID_VoiceManager, 0x62a69bae, 0xdf9d, 0x11d1, 0x99, 0xa6, 0x00, 0xc0, 0x4f, 0xc9, 0x9d, 0x46);
 
 
 HRESULT DSPrimary_PreInit(DSPrimary *prim, DSDevice *parent);
@@ -840,6 +870,10 @@ HRESULT EAXReverb_Get(DSPrimary *prim, DWORD idx, DWORD propid, void *pPropData,
 
 HRESULT EAXChorus_Set(DSPrimary *prim, LONG idx, DWORD propid, void *pPropData, ULONG cbPropData);
 HRESULT EAXChorus_Get(DSPrimary *prim, DWORD idx, DWORD propid, void *pPropData, ULONG cbPropData, ULONG *pcbReturned);
+
+HRESULT VoiceMan_Query(DSBuffer *buf, DWORD propid, ULONG *pTypeSupport);
+HRESULT VoiceMan_Set(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropData);
+HRESULT VoiceMan_Get(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropData, ULONG *pcbReturned);
 
 static inline LONG gain_to_mB(float gain)
 {

--- a/voiceman.c
+++ b/voiceman.c
@@ -1,0 +1,100 @@
+#include "dsound_private.h"
+
+HRESULT VoiceMan_Query(DSBuffer *buf, DWORD propid, ULONG *pTypeSupport) {
+    (void)buf;
+    
+    switch (propid) {
+        case DSPROPERTY_VMANAGER_MODE:
+            TRACE("DSPROPERTY_VMANAGER_MODE\n");
+            *pTypeSupport = KSPROPERTY_SUPPORT_GET | KSPROPERTY_SUPPORT_SET;
+            
+            return DS_OK;
+            
+        case DSPROPERTY_VMANAGER_PRIORITY:
+            TRACE("DSPROPERTY_VMANAGER_PRIORITY\n");
+            *pTypeSupport = KSPROPERTY_SUPPORT_GET | KSPROPERTY_SUPPORT_SET;
+            
+            return DS_OK;
+            
+        case DSPROPERTY_VMANAGER_STATE:
+            TRACE("DSPROPERTY_VMANAGER_STATE\n");
+            *pTypeSupport = KSPROPERTY_SUPPORT_GET;
+            
+            return DS_OK;
+    }
+    
+    FIXME("Unhandled propid: 0x%08lx\n", propid);
+    return E_PROP_ID_UNSUPPORTED;
+}
+
+HRESULT VoiceMan_Set(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropData) {
+    switch (propid) {
+        case DSPROPERTY_VMANAGER_MODE:
+            if (cbPropData >= sizeof(DWORD) && *(DWORD*)pPropData < VMANAGER_MODE_MAX) {
+                TRACE("DSPROPERTY_VMANAGER_MODE set: %d\n", *(DWORD*)pPropData);
+                buf->share->vm_managermode = *(DWORD*)pPropData;
+                
+                return DS_OK;
+            }
+            return DSERR_INVALIDPARAM;
+            
+        case DSPROPERTY_VMANAGER_PRIORITY:
+            if (cbPropData >= sizeof(DWORD)) {
+                TRACE("DSPROPERTY_VMANAGER_PRIORITY set: %d\n", *(DWORD*)pPropData);
+                buf->vm_voicepriority = *(DWORD*)pPropData;
+                
+                return DS_OK;
+            }
+            return DSERR_INVALIDPARAM;
+    }
+    
+    FIXME("Unhandled propid: 0x%08lx\n", propid);
+    return E_PROP_ID_UNSUPPORTED;
+}
+
+HRESULT VoiceMan_Get(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropData, ULONG *pcbReturned) {
+    *pcbReturned = 0;
+    
+    switch (propid) {
+        case DSPROPERTY_VMANAGER_MODE:
+            if (cbPropData >= sizeof(DWORD)) {
+                *pcbReturned = sizeof(DWORD);
+                
+                *(DWORD*)pPropData = buf->share->vm_managermode;
+                TRACE("DSPROPERTY_VMANAGER_MODE get %d\n", *(DWORD*)pPropData);
+                
+                return DS_OK;
+            }
+            return DSERR_INVALIDPARAM;
+            
+        case DSPROPERTY_VMANAGER_PRIORITY:
+            if (cbPropData >= sizeof(DWORD)) {
+                *pcbReturned = sizeof(DWORD);
+                
+                *(DWORD*)pPropData = buf->vm_voicepriority;
+                TRACE("DSPROPERTY_VMANAGER_PRIORITY get %d\n", *(DWORD*)pPropData);
+                
+                return DS_OK;
+            }
+            return DSERR_INVALIDPARAM;
+            
+        case DSPROPERTY_VMANAGER_STATE:
+            if (cbPropData >= sizeof(DWORD)) {
+                *pcbReturned = sizeof(DWORD);
+                
+                /* FIXME: dubious handling */
+                if (buf->isplaying) {
+                    *(DWORD*)pPropData = DSPROPERTY_VMANAGER_STATE_PLAYING3DHW;
+                } else {
+                    *(DWORD*)pPropData = DSPROPERTY_VMANAGER_STATE_SILENT;
+                }
+                TRACE("DSPROPERTY_VMANAGER_STATE get %d\n", *(DWORD*)pPropData);
+                
+                return DS_OK;
+            }
+            return DSERR_INVALIDPARAM;
+    }
+    
+    FIXME("Unhandled propid: 0x%08lx\n", propid);
+    return E_PROP_ID_UNSUPPORTED;
+}

--- a/voiceman.c
+++ b/voiceman.c
@@ -31,7 +31,7 @@ HRESULT VoiceMan_Set(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropD
     switch (propid) {
         case DSPROPERTY_VMANAGER_MODE:
             if (cbPropData >= sizeof(DWORD) && *(DWORD*)pPropData < VMANAGER_MODE_MAX) {
-                TRACE("DSPROPERTY_VMANAGER_MODE set: %d\n", *(DWORD*)pPropData);
+                TRACE("DSPROPERTY_VMANAGER_MODE set: %ld\n", *(DWORD*)pPropData);
                 buf->share->vm_managermode = *(DWORD*)pPropData;
                 
                 return DS_OK;
@@ -40,7 +40,7 @@ HRESULT VoiceMan_Set(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropD
             
         case DSPROPERTY_VMANAGER_PRIORITY:
             if (cbPropData >= sizeof(DWORD)) {
-                TRACE("DSPROPERTY_VMANAGER_PRIORITY set: %d\n", *(DWORD*)pPropData);
+                TRACE("DSPROPERTY_VMANAGER_PRIORITY set: %ld\n", *(DWORD*)pPropData);
                 buf->vm_voicepriority = *(DWORD*)pPropData;
                 
                 return DS_OK;
@@ -61,7 +61,7 @@ HRESULT VoiceMan_Get(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropD
                 *pcbReturned = sizeof(DWORD);
                 
                 *(DWORD*)pPropData = buf->share->vm_managermode;
-                TRACE("DSPROPERTY_VMANAGER_MODE get %d\n", *(DWORD*)pPropData);
+                TRACE("DSPROPERTY_VMANAGER_MODE get %ld\n", *(DWORD*)pPropData);
                 
                 return DS_OK;
             }
@@ -72,7 +72,7 @@ HRESULT VoiceMan_Get(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropD
                 *pcbReturned = sizeof(DWORD);
                 
                 *(DWORD*)pPropData = buf->vm_voicepriority;
-                TRACE("DSPROPERTY_VMANAGER_PRIORITY get %d\n", *(DWORD*)pPropData);
+                TRACE("DSPROPERTY_VMANAGER_PRIORITY get %ld\n", *(DWORD*)pPropData);
                 
                 return DS_OK;
             }
@@ -88,7 +88,7 @@ HRESULT VoiceMan_Get(DSBuffer *buf, DWORD propid, void *pPropData, ULONG cbPropD
                 } else {
                     *(DWORD*)pPropData = DSPROPERTY_VMANAGER_STATE_SILENT;
                 }
-                TRACE("DSPROPERTY_VMANAGER_STATE get %d\n", *(DWORD*)pPropData);
+                TRACE("DSPROPERTY_VMANAGER_STATE get %ld\n", *(DWORD*)pPropData);
                 
                 return DS_OK;
             }


### PR DESCRIPTION
Partial implementation.
The documentation for DSPROPSETID_VoiceManager made appearance only in DX6.x SDKs, as an extra.
Documentation attached.

[DSound_61_extras.zip](https://github.com/kcat/dsoal/files/5313998/DSound_61_extras.zip)
