### PR TITLE
Fix for Music in Guild Wars 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DSOAL-GW1
+
+A fork of DSOAL that works with Guild Wars 1.
+
 # DSOAL
 
 This project is for a DirectSound DLL replacement. It implements the

--- a/dsound8.c
+++ b/dsound8.c
@@ -673,8 +673,8 @@ static HRESULT WINAPI DS8_CreateSoundBuffer(IDirectSound8 *iface, LPCDSBUFFERDES
         {
             if(!IsEqualGUID(&desc->guid3DAlgorithm, &GUID_NULL))
             {
-                WARN("Invalid 3D algorithm GUID specified for non-3D buffer: %s\n", debugstr_guid(&desc->guid3DAlgorithm));
-                return DSERR_INVALIDPARAM;
+                WARN("Invalid 3D algorithm GUID specified for non-3D buffer: %s -- but proceeding anyway!\n", debugstr_guid(&desc->guid3DAlgorithm));
+                //return DSERR_INVALIDPARAM; // Keep going! This must be permitted for the music in Guild Wars 1 to work
             }
         }
         else


### PR DESCRIPTION
It appears that Guild Wars 1 does its music with a non-3D buffer, but with a non-null 3D algorithm GUID. The error checking in DS8_CreateSoundBuffer() bails early on this condition without creating the buffer, resulting in no music. If we remove the early return statement, the music works.

While I'm hesitant to propose remove error checking, I think this might be suitable for merging to master because (1) nothing blew up when I removed it and allowed GW1 to create buffers with this sort of illegal parameter combination, (2) it fixes the problem and makes DSOAL work with GW1, and (3) there maybe other games with the same problem.