### PR TITLE
CI workflow QoL improvements

### DIFF
--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -11,9 +11,10 @@ on:
 env:
   Configuration: Release
   DSOALRepo: ${{github.repository}}
-  DSOALBranch: ${{github.ref_name}}
+  DSOALBranch: master
   OpenALSoftRepo: kcat/openal-soft
   OpenALSoftBranch: master
+  GH_TOKEN: ${{secrets.TOKEN}}
 
 jobs:
   Build:
@@ -31,12 +32,12 @@ jobs:
             platform: "x64"
           }
     steps:
-    
+
     - name: Clone DSOAL
       run: |
         git clone --branch ${{env.DSOALBranch}} https://github.com/${{env.DSOALRepo}}.git .
         git fetch --tags
-        echo "DSOALCommitTag=$(git describe --tags)" >> $env:GITHUB_ENV
+        echo "DSOALCommitTag=$(git tag --list "*.*.*" --contains $(git rev-parse HEAD))" >> $env:GITHUB_ENV
 
     - name: Clone OpenAL Soft
       run: |
@@ -45,7 +46,7 @@ jobs:
         git fetch --tags
         echo "OpenALSoftCommitTag=$(git describe --tags --abbrev=0 --match *.*.*)" >> $env:GITHUB_ENV
         cd "${{github.workspace}}"
-        
+
     - name: Clone OpenAL Soft v${{env.OpenALSoftCommitTag}}
       run: |
         rm openal-soft -r -force
@@ -53,13 +54,15 @@ jobs:
 
     - name: Get version details
       run: |
+        echo "DSOALCommitHash=$(git rev-parse HEAD)" >> $env:GITHUB_ENV
         echo "DSOALCommitHashShort=$(git rev-parse --short=8 HEAD)" >> $env:GITHUB_ENV
         echo "DSOALCommitDate=$(git show -s --date=iso-local --format=%cd)" >> $env:GITHUB_ENV
-        echo "DSOALCommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+        echo "DSOALCommitTitle=$(git show --pretty=format:%s -s HEAD)" >> $env:GITHUB_ENV
         cd "openal-soft"
+        echo "OpenALSoftCommitHash=$(git rev-parse HEAD)" >> $env:GITHUB_ENV
         echo "OpenALSoftCommitHashShort=$(git rev-parse --short=8 HEAD)" >> $env:GITHUB_ENV
         echo "OpenALSoftCommitDate=$(git show -s --date=iso-local --format=%cd)" >> $env:GITHUB_ENV
-        echo "OpenALSoftCommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+        echo "OpenALSoftCommitTitle=$(git show --pretty=format:%s -s HEAD)" >> $env:GITHUB_ENV
         cd "${{github.workspace}}"
 
     - name: Build DSOAL
@@ -82,51 +85,57 @@ jobs:
         copy "${{github.workspace}}/README.md"                                                                 "DSOAL/Documentation/DSOAL-ReadMe.txt"
         copy "${{github.workspace}}/LICENSE"                                                                   "DSOAL/Documentation/DSOAL-License.txt"
         echo "${{env.DSOALRepo}}" >>                                                                           "DSOAL/Documentation/DSOAL-Version.txt"
-        echo "v${{env.DSOALCommitTag}}-${{env.DSOALCommitHashShort}} ${{env.DSOALBranch}}" >>                  "DSOAL/Documentation/DSOAL-Version.txt"
-        echo "Commit #${{env.DSOALCommitCount}}" >>                                                            "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "${{env.DSOALBranch}}" >>                                                                         "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "${{env.DSOALCommitHash}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "v${{env.DSOALCommitTag}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "${{env.DSOALCommitTitle}}" >>                                                                    "DSOAL/Documentation/DSOAL-Version.txt"
         echo "${{env.DSOALCommitDate}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"
         copy "${{github.workspace}}/openal-soft/README.md"                                                     "DSOAL/Documentation/OpenALSoft-ReadMe.txt"
         copy "${{github.workspace}}/openal-soft/COPYING"                                                       "DSOAL/Documentation/OpenALSoft-License.txt"
         copy "${{github.workspace}}/openal-soft/BSD-3Clause"                                                   "DSOAL/Documentation/OpenALSoft-BSD-3Clause.txt"
         copy "${{github.workspace}}/openal-soft/ChangeLog"                                                     "DSOAL/Documentation/OpenALSoft-ChangeLog.txt"
         echo "${{env.OpenALSoftRepo}}" >>                                                                      "DSOAL/Documentation/OpenALSoft-Version.txt"
-        echo "v${{env.OpenALSoftCommitTag}}-${{env.OpenALSoftCommitHashShort}} ${{env.OpenALSoftBranch}}" >>   "DSOAL/Documentation/OpenALSoft-Version.txt"
-        echo "Commit #${{env.OpenALSoftCommitCount}}" >>                                                       "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "${{env.OpenALSoftBranch}}" >>                                                                    "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "${{env.OpenALSoftCommitHash}}" >>                                                                "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "v${{env.OpenALSoftCommitTag}}" >>                                                                "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "${{env.OpenALSoftCommitTitle}}" >>                                                               "DSOAL/Documentation/OpenALSoft-Version.txt"
         echo "${{env.OpenALSoftCommitDate}}" >>                                                                "DSOAL/Documentation/OpenALSoft-Version.txt"
 
     - name: Upload artifact to GitHub actions
       uses: actions/upload-artifact@v4
       with:
-        name: DSOAL_v${{env.DSOALCommitTag}}+OpenALSoft_v${{env.OpenALSoftCommitTag}}-${{matrix.config.name}}
+        name: DSOAL_v${{env.DSOALCommitTag}}-${{env.DSOALCommitHashShort}}+OpenALSoft_v${{env.OpenALSoftCommitTag}}-${{env.OpenALSoftCommitHashShort}}-${{matrix.config.name}}
         path: DSOAL/
 
     outputs:
+      DSOALRepo: ${{env.DSOALRepo}}
       DSOALBranch: ${{env.DSOALBranch}}
+      DSOALCommitHash: ${{env.DSOALCommitHash}}
       DSOALCommitHashShort: ${{env.DSOALCommitHashShort}}
-      DSOALCommitDate: ${{env.DSOALCommitDate}}
-      DSOALCommitCount: ${{env.DSOALCommitCount}}
       DSOALCommitTag: ${{env.DSOALCommitTag}}
+      DSOALCommitTitle: ${{env.DSOALCommitTitle}}
+      DSOALCommitDate: ${{env.DSOALCommitDate}}
       OpenALSoftRepo: ${{env.OpenALSoftRepo}}
       OpenALSoftBranch: ${{env.OpenALSoftBranch}}
+      OpenALSoftCommitHash: ${{env.OpenALSoftCommitHash}}
       OpenALSoftCommitHashShort: ${{env.OpenALSoftCommitHashShort}}
-      OpenALSoftCommitDate: ${{env.OpenALSoftCommitDate}}
-      OpenALSoftCommitCount: ${{env.OpenALSoftCommitCount}}
       OpenALSoftCommitTag: ${{env.OpenALSoftCommitTag}}
+      OpenALSoftCommitTitle: ${{env.OpenALSoftCommitTitle}}
+      OpenALSoftCommitDate: ${{env.OpenALSoftCommitDate}}
 
   Release:
     needs: Build
     runs-on: ubuntu-latest
     steps:
 
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
-      with:
-        path: Release
+    - name: Download build artifacts
+      run: |
+        gh run download ${{github.run_id}} --repo ${{env.DSOALRepo}} --dir Release
 
     - name: Collect binaries
       run: |
-        mv "Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}+OpenALSoft_v${{needs.Build.outputs.OpenALSoftCommitTag}}-Win32" "Release/Win32"
-        mv "Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}+OpenALSoft_v${{needs.Build.outputs.OpenALSoftCommitTag}}-Win64" "Release/Win64"
+        mv "Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}-${{needs.Build.outputs.DSOALCommitHashShort}}+OpenALSoft_v${{needs.Build.outputs.OpenALSoftCommitTag}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}}-Win32" "Release/Win32"
+        mv "Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}-${{needs.Build.outputs.DSOALCommitHashShort}}+OpenALSoft_v${{needs.Build.outputs.OpenALSoftCommitTag}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}}-Win64" "Release/Win64"
         mkdir "Release/DSOAL"
         mv "Release/Win32" "Release/DSOAL/Win32"
         mv "Release/Win64" "Release/DSOAL/Win64"
@@ -140,15 +149,17 @@ jobs:
 
     - name: Compress artifacts
       run: |
-        cd Release
-        7z a DSOAL.zip      ./DSOAL/*
-        7z a DSOAL+HRTF.zip ./DSOAL+HRTF/*
+        7z a ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
+        7z a DSOAL.zip ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -m0=lzma -mx=9
 
-    - name: GitHub pre-release
-      uses: "slord399/action-automatic-releases@v1.0.1"
-      with:
-        repo_token: "${{secrets.GITHUB_TOKEN}}"
-        automatic_release_tag: "${{needs.Build.outputs.DSOALCommitTag}}"
-        prerelease: false
-        title: "DSOAL v${{needs.Build.outputs.DSOALCommitTag}} + OpenAL Soft v${{needs.Build.outputs.OpenALSoftCommitTag}}"
-        files: "Release/*"
+    - name: Purge tag - ${{needs.Build.outputs.DSOALCommitTag}}
+      continue-on-error: true
+      run: |
+        gh release delete ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes
+
+    - name: Release - ${{needs.Build.outputs.DSOALCommitTag}}
+      run: |
+        gh release create ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --target ${{needs.Build.outputs.DSOALCommitHash}} --generate-notes --latest=true --title "DSOAL v${{needs.Build.outputs.DSOALCommitTag}} + OpenAL Soft v${{needs.Build.outputs.OpenALSoftCommitTag}}" --notes "DSOAL v${{needs.Build.outputs.DSOALCommitTag}}-${{needs.Build.outputs.DSOALCommitHashShort}} ${{needs.Build.outputs.DSOALBranch}} - ${{needs.Build.outputs.DSOALCommitTitle}} [${{needs.Build.outputs.DSOALCommitDate}}]
+        OpenAL Soft v${{needs.Build.outputs.OpenALSoftCommitTag}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}} ${{needs.Build.outputs.OpenALSoftBranch}} - ${{needs.Build.outputs.OpenALSoftCommitTitle}} [${{needs.Build.outputs.OpenALSoftCommitDate}}]
+        Build log: https://github.com/${{env.DSOALRepo}}/actions/runs/${{github.run_id}}"
+        gh release upload ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip

--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -153,9 +153,8 @@ jobs:
         7z a DSOAL.zip ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -m0=lzma -mx=9
 
     - name: Purge tag - ${{needs.Build.outputs.DSOALCommitTag}}
-      continue-on-error: true
       run: |
-        gh release delete ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes
+        gh release delete ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes || true
 
     - name: Release - ${{needs.Build.outputs.DSOALCommitTag}}
       run: |

--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -14,7 +14,7 @@ env:
   DSOALBranch: master
   OpenALSoftRepo: kcat/openal-soft
   OpenALSoftBranch: master
-  GH_TOKEN: ${{secrets.TOKEN}}
+  GH_TOKEN: ${{github.token}}
 
 jobs:
   Build:

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -18,7 +18,7 @@ env:
   DSOALBranch: ${{github.ref_name}}
   OpenALSoftRepo: kcat/openal-soft
   OpenALSoftBranch: master
-  GH_TOKEN: ${{secrets.TOKEN}}
+  GH_TOKEN: ${{github.token}}
 
 jobs:
   Build:

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -153,7 +153,7 @@ jobs:
 
     - name: Purge tag - latest-${{needs.Build.outputs.DSOALBranch}}
       run: |
-        gh release delete latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --cleanup-tag -- || true
+        gh release delete latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes || true
 
     - name: Release - r${{needs.Build.outputs.DSOALCommitCount}}
       run: |

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -3,14 +3,14 @@ name: Untagged build
 on:
   push:
     branches:
-      - '*'
-    tags-ignore:
-      - '*.*.*'
+      - "**"
+    tags:
+      - "!**"
     paths-ignore:
       - '.github/workflows/Tagged.yaml'
+  workflow_dispatch:
   schedule:
   - cron: '0 0 * * *'
-  workflow_dispatch:
 
 env:
   Configuration: Release
@@ -18,6 +18,7 @@ env:
   DSOALBranch: ${{github.ref_name}}
   OpenALSoftRepo: kcat/openal-soft
   OpenALSoftBranch: master
+  GH_TOKEN: ${{secrets.TOKEN}}
 
 jobs:
   Build:
@@ -35,7 +36,7 @@ jobs:
             platform: "x64"
           }
     steps:
-    
+
     - name: Clone DSOAL
       run: |
         git clone --branch ${{env.DSOALBranch}} https://github.com/${{env.DSOALRepo}}.git .
@@ -46,13 +47,17 @@ jobs:
 
     - name: Get version details
       run: |
+        echo "DSOALCommitHash=$(git rev-parse HEAD)" >> $env:GITHUB_ENV
         echo "DSOALCommitHashShort=$(git rev-parse --short=8 HEAD)" >> $env:GITHUB_ENV
         echo "DSOALCommitDate=$(git show -s --date=iso-local --format=%cd)" >> $env:GITHUB_ENV
         echo "DSOALCommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+        echo "DSOALCommitTitle=$(git show --pretty=format:%s -s HEAD)" >> $env:GITHUB_ENV
         cd "openal-soft"
+        echo "OpenALSoftCommitHash=$(git rev-parse HEAD)" >> $env:GITHUB_ENV
         echo "OpenALSoftCommitHashShort=$(git rev-parse --short=8 HEAD)" >> $env:GITHUB_ENV
         echo "OpenALSoftCommitDate=$(git show -s --date=iso-local --format=%cd)" >> $env:GITHUB_ENV
         echo "OpenALSoftCommitCount=$(git rev-list --count HEAD)" >> $env:GITHUB_ENV
+        echo "OpenALSoftCommitTitle=$(git show --pretty=format:%s -s HEAD)" >> $env:GITHUB_ENV
         cd "${{github.workspace}}"
 
     - name: Build DSOAL
@@ -75,47 +80,57 @@ jobs:
         copy "${{github.workspace}}/README.md"                                                                 "DSOAL/Documentation/DSOAL-ReadMe.txt"
         copy "${{github.workspace}}/LICENSE"                                                                   "DSOAL/Documentation/DSOAL-License.txt"
         echo "${{env.DSOALRepo}}" >>                                                                           "DSOAL/Documentation/DSOAL-Version.txt"
-        echo "r${{env.DSOALCommitCount}}@${{env.DSOALCommitHashShort}} ${{env.DSOALBranch}}" >>                "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "${{env.DSOALBranch}}" >>                                                                         "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "${{env.DSOALCommitHash}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "r${{env.DSOALCommitCount}}" >>                                                                   "DSOAL/Documentation/DSOAL-Version.txt"
+        echo "${{env.DSOALCommitTitle}}" >>                                                                    "DSOAL/Documentation/DSOAL-Version.txt"
         echo "${{env.DSOALCommitDate}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"
         copy "${{github.workspace}}/openal-soft/README.md"                                                     "DSOAL/Documentation/OpenALSoft-ReadMe.txt"
         copy "${{github.workspace}}/openal-soft/COPYING"                                                       "DSOAL/Documentation/OpenALSoft-License.txt"
         copy "${{github.workspace}}/openal-soft/BSD-3Clause"                                                   "DSOAL/Documentation/OpenALSoft-BSD-3Clause.txt"
         copy "${{github.workspace}}/openal-soft/ChangeLog"                                                     "DSOAL/Documentation/OpenALSoft-ChangeLog.txt"
         echo "${{env.OpenALSoftRepo}}" >>                                                                      "DSOAL/Documentation/OpenALSoft-Version.txt"
-        echo "r${{env.OpenALSoftCommitCount}}@${{env.OpenALSoftCommitHashShort}} ${{env.OpenALSoftBranch}}" >> "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "${{env.OpenALSoftBranch}}" >>                                                                    "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "${{env.OpenALSoftCommitHash}}" >>                                                                "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "r${{env.OpenALSoftCommitCount}}" >>                                                              "DSOAL/Documentation/OpenALSoft-Version.txt"
+        echo "${{env.OpenALSoftCommitTitle}}" >>                                                               "DSOAL/Documentation/OpenALSoft-Version.txt"
         echo "${{env.OpenALSoftCommitDate}}" >>                                                                "DSOAL/Documentation/OpenALSoft-Version.txt"
 
     - name: Upload artifact to GitHub actions
       uses: actions/upload-artifact@v4
       with:
-        name: DSOAL_r${{env.DSOALCommitCount}}@${{env.DSOALCommitHashShort}}+OpenALSoft_r${{env.OpenALSoftCommitCount}}@${{env.OpenALSoftCommitHashShort}}-${{matrix.config.name}}
+        name: DSOAL_r${{env.DSOALCommitCount}}-${{env.DSOALCommitHashShort}}+OpenALSoft_r${{env.OpenALSoftCommitCount}}-${{env.OpenALSoftCommitHashShort}}-${{matrix.config.name}}
         path: DSOAL/
 
     outputs:
+      DSOALRepo: ${{env.DSOALRepo}}
       DSOALBranch: ${{env.DSOALBranch}}
+      DSOALCommitHash: ${{env.DSOALCommitHash}}
       DSOALCommitHashShort: ${{env.DSOALCommitHashShort}}
-      DSOALCommitDate: ${{env.DSOALCommitDate}}
       DSOALCommitCount: ${{env.DSOALCommitCount}}
+      DSOALCommitTitle: ${{env.DSOALCommitTitle}}
+      DSOALCommitDate: ${{env.DSOALCommitDate}}
       OpenALSoftRepo: ${{env.OpenALSoftRepo}}
       OpenALSoftBranch: ${{env.OpenALSoftBranch}}
+      OpenALSoftCommitHash: ${{env.OpenALSoftCommitHash}}
       OpenALSoftCommitHashShort: ${{env.OpenALSoftCommitHashShort}}
-      OpenALSoftCommitDate: ${{env.OpenALSoftCommitDate}}
       OpenALSoftCommitCount: ${{env.OpenALSoftCommitCount}}
+      OpenALSoftCommitTitle: ${{env.OpenALSoftCommitTitle}}
+      OpenALSoftCommitDate: ${{env.OpenALSoftCommitDate}}
 
   Release:
     needs: Build
     runs-on: ubuntu-latest
     steps:
 
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v4
-      with:
-        path: Release
+    - name: Download build artifacts
+      run: |
+        gh run download ${{github.run_id}} --repo ${{env.DSOALRepo}} --dir Release
 
     - name: Collect binaries
       run: |
-        mv "Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}@${{needs.Build.outputs.DSOALCommitHashShort}}+OpenALSoft_r${{needs.Build.outputs.OpenALSoftCommitCount}}@${{needs.Build.outputs.OpenALSoftCommitHashShort}}-Win32" "Release/Win32"
-        mv "Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}@${{needs.Build.outputs.DSOALCommitHashShort}}+OpenALSoft_r${{needs.Build.outputs.OpenALSoftCommitCount}}@${{needs.Build.outputs.OpenALSoftCommitHashShort}}-Win64" "Release/Win64"
+        mv "Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}-${{needs.Build.outputs.DSOALCommitHashShort}}+OpenALSoft_r${{needs.Build.outputs.OpenALSoftCommitCount}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}}-Win32" "Release/Win32"
+        mv "Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}-${{needs.Build.outputs.DSOALCommitHashShort}}+OpenALSoft_r${{needs.Build.outputs.OpenALSoftCommitCount}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}}-Win64" "Release/Win64"
         mkdir "Release/DSOAL"
         mv "Release/Win32" "Release/DSOAL/Win32"
         mv "Release/Win64" "Release/DSOAL/Win64"
@@ -129,24 +144,29 @@ jobs:
 
     - name: Compress artifacts
       run: |
-        cd Release
-        7z a DSOAL.zip      ./DSOAL/*
-        7z a DSOAL+HRTF.zip ./DSOAL+HRTF/*
+        7z a ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
+        7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -m0=lzma -mx=9
 
-    - name: GitHub pre-release - r${{needs.Build.outputs.DSOALCommitCount}} tag
-      uses: "slord399/action-automatic-releases@v1.0.1"
-      with:
-        repo_token: "${{secrets.GITHUB_TOKEN}}"
-        automatic_release_tag: "r${{needs.Build.outputs.DSOALCommitCount}}"
-        prerelease: true
-        title: "DSOAL r${{needs.Build.outputs.DSOALCommitCount}}@${{needs.Build.outputs.DSOALCommitHashShort}} + OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}@${{needs.Build.outputs.OpenALSoftCommitHashShort}}"
-        files: "Release/*"
+    - name: Purge tag - r${{needs.Build.outputs.DSOALCommitCount}}
+      continue-on-error: true
+      run: |
+        gh release delete r${{needs.Build.outputs.DSOALCommitCount}}  --repo ${{env.DSOALRepo}} --cleanup-tag --yes
 
-    - name: GitHub pre-release - latest tag
-      uses: "slord399/action-automatic-releases@v1.0.1"
-      with:
-        repo_token: "${{secrets.GITHUB_TOKEN}}"
-        automatic_release_tag: "latest-${{needs.Build.outputs.DSOALBranch}}"
-        prerelease: true
-        title: "DSOAL r${{needs.Build.outputs.DSOALCommitCount}}@${{needs.Build.outputs.DSOALCommitHashShort}} + OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}@${{needs.Build.outputs.OpenALSoftCommitHashShort}}"
-        files: "Release/*"
+    - name: Purge tag - latest-${{needs.Build.outputs.DSOALBranch}}
+      continue-on-error: true
+      run: |
+        gh release delete latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes
+
+    - name: Release - r${{needs.Build.outputs.DSOALCommitCount}}
+      run: |
+        gh release create r${{needs.Build.outputs.DSOALCommitCount}} --repo ${{env.DSOALRepo}} --target ${{needs.Build.outputs.DSOALCommitHash}} --generate-notes --latest=false --prerelease --title "DSOAL r${{needs.Build.outputs.DSOALCommitCount}} + OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}" --notes "DSOAL r${{needs.Build.outputs.DSOALCommitCount}}-${{needs.Build.outputs.DSOALCommitHashShort}} ${{needs.Build.outputs.DSOALBranch}} - ${{needs.Build.outputs.DSOALCommitTitle}} [${{needs.Build.outputs.DSOALCommitDate}}]
+        OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}} ${{needs.Build.outputs.OpenALSoftBranch}} - ${{needs.Build.outputs.OpenALSoftCommitTitle}} [${{needs.Build.outputs.OpenALSoftCommitDate}}]
+        Build log: https://github.com/${{env.DSOALRepo}}/actions/runs/${{github.run_id}}"
+        gh release upload r${{needs.Build.outputs.DSOALCommitCount}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip
+
+    - name: Release - latest-${{needs.Build.outputs.DSOALBranch}}
+      run: |
+        gh release create latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --target ${{needs.Build.outputs.DSOALCommitHash}} --generate-notes --latest=true --prerelease --title "DSOAL r${{needs.Build.outputs.DSOALCommitCount}} + OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}" --notes "DSOAL r${{needs.Build.outputs.DSOALCommitCount}}-${{needs.Build.outputs.DSOALCommitHashShort}} ${{needs.Build.outputs.DSOALBranch}} - ${{needs.Build.outputs.DSOALCommitTitle}} [${{needs.Build.outputs.DSOALCommitDate}}]
+        OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}} ${{needs.Build.outputs.OpenALSoftBranch}} - ${{needs.Build.outputs.OpenALSoftCommitTitle}} [${{needs.Build.outputs.OpenALSoftCommitDate}}]
+        Build log: https://github.com/${{env.DSOALRepo}}/actions/runs/${{github.run_id}}"
+        gh release upload latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -148,14 +148,12 @@ jobs:
         7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -m0=lzma -mx=9
 
     - name: Purge tag - r${{needs.Build.outputs.DSOALCommitCount}}
-      continue-on-error: true
       run: |
-        gh release delete r${{needs.Build.outputs.DSOALCommitCount}}  --repo ${{env.DSOALRepo}} --cleanup-tag --yes
+        gh release delete r${{needs.Build.outputs.DSOALCommitCount}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes || true
 
     - name: Purge tag - latest-${{needs.Build.outputs.DSOALBranch}}
-      continue-on-error: true
       run: |
-        gh release delete latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes
+        gh release delete latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --cleanup-tag -- || true
 
     - name: Release - r${{needs.Build.outputs.DSOALCommitCount}}
       run: |


### PR DESCRIPTION
As discussed in https://github.com/kcat/dsoal/pull/52#issuecomment-2609150403, here are some changes I had proposed, plus some QoL improvements and fixes:
- Include full commit hash in Version.txt files
- Include commit title in release description and Version.txt files (might wanna avoid unescaped special characters like quotes)
- Improve compression with nested zip files (uncompressed zip inside a max compressed zip) to work around its lack of solid compression, for compression ratio comparable to 7-zip, ~1/3 of regular zip, 1/6 of the uncompressed files, while still maintaining backwards compatibility with systems that can't extract 7z files out of the box. This could allow adding more pre-configured builds with negligible filesize increase.
- Replace all third-party actions with standard commands. Only action left is the official [artifact upload](https://github.com/ThreeDeeJay/dsoal/blob/68bf331dcf97f83f580c3ee3012167bfe69a8b55/.github/workflows/Tagged.yaml#L104-L108) since [there's no way to upload artifacts via the CLI](https://github.com/cli/cli/issues/5416) like we can [download](https://cli.github.com/manual/gh_run_download) them
- Fix tagged release using tag instead of branch name by hardcoding the `master` branch, since GitHub made it ridiculously hard to get the current commit's branch when the workflow has been triggered by a tag.
- Fix infinite loop that triggers a new build when creating a release tag by making the untagged workflow trigger ignore all tags (including, e.g.: r123, created upon release), not just *.*.*

Additional notes:
- DSOAL still gets rebuilt daily and they're labeled as Scheduled in the [Actions page](https://github.com/kcat/dsoal/actions) so that the latest build always has a recent OpenAL Soft. I think it's possible to trigger a new build upon OALS commits, but it requires some advanced webhooks on both repos that I haven't quite gotten my head around to.
- Since every workflow run releases both a r### and latest-branch tags, daily builds will overwrite the previous one. e.g.: the original [r647](https://github.com/kcat/dsoal/actions/runs/13135473309) may not the the same as [r647 from a few days later](https://github.com/kcat/dsoal/actions/runs/13191081897) if OpenAL Soft was updated in the meantime. But at least now we know the version for each file in the Version.txt and log.
- If you want to release a stable build, you only gotta add a semver (`*.*.*`) tag to a commit and push it. That'll trigger a stable build that uses the last stable OpenAL Soft, so it might be a good idea to create it shortly after a stable OALS release 👀👌

So e.g.:
https://github.com/ThreeDeeJay/dsoal/releases/tag/r648 - Triggered by new commits and daily schedule, may get overwritten
https://github.com/ThreeDeeJay/dsoal/releases/tag/latest-master - Same as above, except it always gets overwritten
https://github.com/ThreeDeeJay/dsoal/releases/tag/0.9.8 - Triggered by manually pushing a `*.*.*` tag, never gets overwritten (unless the tag gets re-assigned to another commit?)