### PR TITLE
Upload builds to shared archive release tag

### DIFF
--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -147,20 +147,14 @@ jobs:
         7z a ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
         7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -m0=lzma -mx=9
 
-    - name: Purge tag - r${{needs.Build.outputs.DSOALCommitCount}}
-      run: |
-        gh release delete r${{needs.Build.outputs.DSOALCommitCount}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes || true
-
     - name: Purge tag - latest-${{needs.Build.outputs.DSOALBranch}}
       run: |
         gh release delete latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --cleanup-tag --yes || true
 
-    - name: Release - r${{needs.Build.outputs.DSOALCommitCount}}
+    - name: Release - archive
       run: |
-        gh release create r${{needs.Build.outputs.DSOALCommitCount}} --repo ${{env.DSOALRepo}} --target ${{needs.Build.outputs.DSOALCommitHash}} --generate-notes --latest=false --prerelease --title "DSOAL r${{needs.Build.outputs.DSOALCommitCount}} + OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}" --notes "DSOAL r${{needs.Build.outputs.DSOALCommitCount}}-${{needs.Build.outputs.DSOALCommitHashShort}} ${{needs.Build.outputs.DSOALBranch}} - ${{needs.Build.outputs.DSOALCommitTitle}} [${{needs.Build.outputs.DSOALCommitDate}}]
-        OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}} ${{needs.Build.outputs.OpenALSoftBranch}} - ${{needs.Build.outputs.OpenALSoftCommitTitle}} [${{needs.Build.outputs.OpenALSoftCommitDate}}]
-        Build log: https://github.com/${{env.DSOALRepo}}/actions/runs/${{github.run_id}}"
-        gh release upload r${{needs.Build.outputs.DSOALCommitCount}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip
+        gh release create archive --repo ${{env.DSOALRepo}} --target 98584ab11d231d36488bc055bdeb19b607706bc6 --latest=false --prerelease --title "DSOAL build archive" || true
+        gh release upload archive --repo ${{env.DSOALRepo}} --clobber DSOAL.zip#DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip
 
     - name: Release - latest-${{needs.Build.outputs.DSOALBranch}}
       run: |

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -146,6 +146,7 @@ jobs:
       run: |
         7z a ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
         7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -m0=lzma -mx=9
+        cp DSOAL.zip DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip
 
     - name: Purge tag - latest-${{needs.Build.outputs.DSOALBranch}}
       run: |
@@ -154,7 +155,7 @@ jobs:
     - name: Release - archive
       run: |
         gh release create archive --repo ${{env.DSOALRepo}} --target 98584ab11d231d36488bc055bdeb19b607706bc6 --latest=false --prerelease --title "DSOAL build archive" || true
-        gh release upload archive --repo ${{env.DSOALRepo}} --clobber DSOAL.zip#DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip
+        gh release upload archive --repo ${{env.DSOALRepo}} --clobber DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip
 
     - name: Release - latest-${{needs.Build.outputs.DSOALBranch}}
       run: |


### PR DESCRIPTION
This PR addresses tag clutter pointed out in https://github.com/kcat/dsoal/pull/113#issuecomment-2646054325
Basically instead of creating a new `r###` tag for every release, it (re-)uses the `archive` tag (can be renamed to something else) and uploads every `DSOAL_r###.zip` to it, which luckily we can do now with the cli commands since the old action didn't allow it.
Anyway, instead of, e.g.:
`https://github.com/ThreeDeeJay/dsoal/releases/download/r650/DSOAL.zip`
it'll use:
https://github.com/ThreeDeeJay/dsoal/releases/download/archive/DSOAL_r650.zip

Note, since releases have to be tied to a specific commit, and I'm not sure if changing it is possible, I just used the initial commit 98584ab11d231d36488bc055bdeb19b607706bc6: https://github.com/ThreeDeeJay/dsoal/releases/archive

So it should be safe to delete the `r###` tags and their associated releases, though it'd be nice if there was a way to compile all the past builds into the new `archive` tag. I could revise my [build-all.yaml](https://github.com/ThreeDeeJay/dsoal/blob/build-all/.github/workflows/build-all.yaml) workflow that I cobbled together though it relied on checking for released tags and I'm not sure how to check if a specific filename exists to know whether it should be compiled if using multiple runs since Actions only allows 256 at a time 🤔 