### PR TITLE
Include fmt license in CI builds

### DIFF
--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -84,6 +84,7 @@ jobs:
         copy "${{github.workspace}}/openal-soft/alsoftrc.sample"                                               "DSOAL/alsoft.ini"
         copy "${{github.workspace}}/README.md"                                                                 "DSOAL/Documentation/DSOAL-ReadMe.txt"
         copy "${{github.workspace}}/LICENSE"                                                                   "DSOAL/Documentation/DSOAL-License.txt"
+        copy "${{github.workspace}}/fmt-11.1.1/LICENSE"                                                        "DSOAL/Documentation/DSOAL-License_fmt.txt"
         echo "${{env.DSOALRepo}}" >>                                                                           "DSOAL/Documentation/DSOAL-Version.txt"
         echo "${{env.DSOALBranch}}" >>                                                                         "DSOAL/Documentation/DSOAL-Version.txt"
         echo "${{env.DSOALCommitHash}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -79,6 +79,7 @@ jobs:
         copy "${{github.workspace}}/openal-soft/alsoftrc.sample"                                               "DSOAL/alsoft.ini"
         copy "${{github.workspace}}/README.md"                                                                 "DSOAL/Documentation/DSOAL-ReadMe.txt"
         copy "${{github.workspace}}/LICENSE"                                                                   "DSOAL/Documentation/DSOAL-License.txt"
+        copy "${{github.workspace}}/fmt-11.1.1/LICENSE"                                                        "DSOAL/Documentation/DSOAL-License_fmt.txt"
         echo "${{env.DSOALRepo}}" >>                                                                           "DSOAL/Documentation/DSOAL-Version.txt"
         echo "${{env.DSOALBranch}}" >>                                                                         "DSOAL/Documentation/DSOAL-Version.txt"
         echo "${{env.DSOALCommitHash}}" >>                                                                     "DSOAL/Documentation/DSOAL-Version.txt"


### PR DESCRIPTION
Just noticed I missed this one in https://github.com/kcat/dsoal/pull/117