### PR TITLE
Fixup MSVC Warnings

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -630,7 +630,7 @@ HRESULT Buffer::setLocation(LocStatus locStatus) noexcept
 
             const auto slots = std::as_writable_bytes(std::span{NullSlots});
             EAXSetDirect(mContext, &EAXPROPERTYID_EAX40_Source, EAXSOURCE_ACTIVEFXSLOTID, mSource,
-                slots.data(), slots.size());
+                slots.data(), static_cast<ALuint>(slots.size()));
         }
     }
     alGetErrorDirect(mContext);

--- a/src/propset.cpp
+++ b/src/propset.cpp
@@ -222,9 +222,9 @@ HRESULT DSPROPERTY_DescriptionW(void *pPropData, ULONG cbPropData, ULONG *pcbRet
     }
 
     ppd->Type = DIRECTSOUNDDEVICE_TYPE_WDM;
-    ppd->Description = wcsdup(pv.value<const WCHAR*>());
-    ppd->Module = wcsdup(std::data(aldriver_name));
-    ppd->Interface = wcsdup(L"Interface");
+    ppd->Description = _wcsdup(pv.value<const WCHAR*>());
+    ppd->Module = _wcsdup(std::data(aldriver_name));
+    ppd->Interface = _wcsdup(L"Interface");
 
     if(pcbReturned)
         *pcbReturned = sizeof(*ppd);


### PR DESCRIPTION
Fixes the following warnings.

```
buffer.cpp
dsoal\src\buffer.cpp(633,41): warning C4267: 'argument': conversion from 'size_t' to 'ALuint', possible loss of data

propset.cpp
dsoal\src\propset.cpp(225,24): warning C4996: 'wcsdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsdup. See online help for details.
dsoal\src\propset.cpp(226,19): warning C4996: 'wcsdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsdup. See online help for details.
dsoal\src\propset.cpp(227,22): warning C4996: 'wcsdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _wcsdup. See online help for details.
```