### PR TITLE
Disable LZMA for ZIP, and add 7-Zip

### DIFF
--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -152,7 +152,10 @@ jobs:
     - name: Compress artifacts
       run: |
         7z a ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
-        7z a DSOAL.zip ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -m0=lzma -mx=9
+        7z a DSOAL.zip ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -mx=9
+        7z a DSOAL.7z  ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -mx=9 -m0=lzma2
+        cp DSOAL.zip DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip
+        cp DSOAL.7z  DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.7z
 
     - name: Purge tag - ${{needs.Build.outputs.DSOALCommitTag}}
       run: |
@@ -163,4 +166,4 @@ jobs:
         gh release create ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --target ${{needs.Build.outputs.DSOALCommitHash}} --generate-notes --latest=true --title "DSOAL v${{needs.Build.outputs.DSOALCommitTag}} + OpenAL Soft v${{needs.Build.outputs.OpenALSoftCommitTag}}" --notes "DSOAL v${{needs.Build.outputs.DSOALCommitTag}}-${{needs.Build.outputs.DSOALCommitHashShort}} ${{needs.Build.outputs.DSOALBranch}} - ${{needs.Build.outputs.DSOALCommitTitle}} [${{needs.Build.outputs.DSOALCommitDate}}]
         OpenAL Soft v${{needs.Build.outputs.OpenALSoftCommitTag}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}} ${{needs.Build.outputs.OpenALSoftBranch}} - ${{needs.Build.outputs.OpenALSoftCommitTitle}} [${{needs.Build.outputs.OpenALSoftCommitDate}}]
         Build log: https://github.com/${{env.DSOALRepo}}/actions/runs/${{github.run_id}}"
-        gh release upload ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip
+        gh release upload ${{needs.Build.outputs.DSOALCommitTag}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip DSOAL.7z

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -147,8 +147,10 @@ jobs:
     - name: Compress artifacts
       run: |
         7z a ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
-        7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -m0=lzma -mx=9
+        7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -mx=9
+        7z a DSOAL.7z  ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -mx=9 -m0=lzma2
         cp DSOAL.zip DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip
+        cp DSOAL.7z  DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.7z
 
     - name: Purge tag - latest-${{needs.Build.outputs.DSOALBranch}}
       run: |
@@ -164,4 +166,4 @@ jobs:
         gh release create latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --target ${{needs.Build.outputs.DSOALCommitHash}} --generate-notes --latest=true --prerelease --title "DSOAL r${{needs.Build.outputs.DSOALCommitCount}} + OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}" --notes "DSOAL r${{needs.Build.outputs.DSOALCommitCount}}-${{needs.Build.outputs.DSOALCommitHashShort}} ${{needs.Build.outputs.DSOALBranch}} - ${{needs.Build.outputs.DSOALCommitTitle}} [${{needs.Build.outputs.DSOALCommitDate}}]
         OpenAL Soft r${{needs.Build.outputs.OpenALSoftCommitCount}}-${{needs.Build.outputs.OpenALSoftCommitHashShort}} ${{needs.Build.outputs.OpenALSoftBranch}} - ${{needs.Build.outputs.OpenALSoftCommitTitle}} [${{needs.Build.outputs.OpenALSoftCommitDate}}]
         Build log: https://github.com/${{env.DSOALRepo}}/actions/runs/${{github.run_id}}"
-        gh release upload latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip
+        gh release upload latest-${{needs.Build.outputs.DSOALBranch}} --repo ${{env.DSOALRepo}} --clobber DSOAL.zip DSOAL.7z


### PR DESCRIPTION
- LZMA (used for solid compression for lowest filesize) used for the parent ZIP file fails to extract on Windows Explorer, defeating the purpose of convenience by not having to install 7-Zip. So it has been disabled for the user's convenience, at the cost of making the file bigger.
![424357288-7cd07cf7-bc60-4993-9e4b-eebd3dba37b5](https://github.com/user-attachments/assets/bd9f9ab4-db9f-42b9-a30e-9e1bd2b2c9ea)
![424354450-02bdb016-e4b6-4e8e-8da9-9f4bcfc3d88d-1](https://github.com/user-attachments/assets/a9d46adc-5aeb-44ff-afaf-6763a0f189b4)

- An additional 7-Zip file has been added for those who do already have means to extract 7Z, while its filesize remains as low as possible.

As this shows, the Zip file will be 3 times bigger compared to the current size and 7z.
![image](https://github.com/user-attachments/assets/2a26ad10-3357-4639-ac9d-52d5f3ea25be)
https://github.com/ThreeDeeJay/dsoal/releases/tag/latest-compression

It was reported a while ago here https://github.com/ThreeDeeJay/dsoal/issues/6#issuecomment-2736474184
But I just thought about this compromise recently and finally got a chance to test it. 
I'm not sure if this is the most ideal solution, though, so I'm open to suggestions.