### PR TITLE
Don't use nested Zip inside 7z

### DIFF
--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -153,7 +153,7 @@ jobs:
       run: |
         7z a ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
         7z a DSOAL.zip ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -mx=9
-        7z a DSOAL.7z  ./Release/DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip -mx=9 -m0=lzma2
+        7z a DSOAL.7z  ./Release/DSOAL ./Release/DSOAL+HRTF -mx=9 -m0=lzma2
         cp DSOAL.zip DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.zip
         cp DSOAL.7z  DSOAL_v${{needs.Build.outputs.DSOALCommitTag}}.7z
 

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -148,7 +148,7 @@ jobs:
       run: |
         7z a ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip ./Release/DSOAL ./Release/DSOAL+HRTF -m0=Copy
         7z a DSOAL.zip ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -mx=9
-        7z a DSOAL.7z  ./Release/DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip -mx=9 -m0=lzma2
+        7z a DSOAL.7z  ./Release/DSOAL ./Release/DSOAL+HRTF -mx=9 -m0=lzma2
         cp DSOAL.zip DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.zip
         cp DSOAL.7z  DSOAL_r${{needs.Build.outputs.DSOALCommitCount}}.7z
 


### PR DESCRIPTION
7z supports solid compression so the nested Zip workaround is unnecessary.
Also, not using the versioned Zip should simplify extraction for DSOAL installer scripts.