### PR TITLE
Add script to run with logging

### DIFF
--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -143,6 +143,8 @@ jobs:
         mv "Release/Win64" "Release/DSOAL/Win64"
         mv "Release/DSOAL/Win32/Documentation" "Release/DSOAL/Documentation"
         rm -r "Release/DSOAL/Win64/Documentation"
+        mkdir "Release/DSOAL/Tools"
+        curl "https://raw.githubusercontent.com/ThreeDeeJay/ALog/589fcceaf73aedde1c959abe5cf5c88a812a1dcf/Drop%20exe%20to%20run%20with%20logging.bat" -o "Release/DSOAL/Tools/Drop exe to run with logging.bat"
         cp -R "Release/DSOAL" "Release/DSOAL+HRTF"
         mv "Release/DSOAL+HRTF/Win32/alsoft.ini" "Release/DSOAL+HRTF/Documentation/alsoft.ini"
         rm "Release/DSOAL+HRTF/Win64/alsoft.ini"

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -138,6 +138,8 @@ jobs:
         mv "Release/Win64" "Release/DSOAL/Win64"
         mv "Release/DSOAL/Win32/Documentation" "Release/DSOAL/Documentation"
         rm -r "Release/DSOAL/Win64/Documentation"
+        mkdir "Release/DSOAL/Tools"
+        curl "https://raw.githubusercontent.com/ThreeDeeJay/ALog/589fcceaf73aedde1c959abe5cf5c88a812a1dcf/Drop%20exe%20to%20run%20with%20logging.bat" -o "Release/DSOAL/Tools/Drop exe to run with logging.bat"
         cp -R "Release/DSOAL" "Release/DSOAL+HRTF"
         mv "Release/DSOAL+HRTF/Win32/alsoft.ini" "Release/DSOAL+HRTF/Documentation/alsoft.ini"
         rm "Release/DSOAL+HRTF/Win64/alsoft.ini"


### PR DESCRIPTION
Figured this could be useful to save time explaining how to enable logging for new users submitting issues.
And since this is a third-party script, the workflow downloads a static commit (current) version so you know there's no funny business. 👀👌 