### PR TITLE
Strip DSBCAPS_LOCSOFTWARE from buffer initalization flags

### DIFF
--- a/src/primarybuffer.cpp
+++ b/src/primarybuffer.cpp
@@ -304,12 +304,15 @@ HRESULT STDMETHODCALLTYPE PrimaryBuffer::Initialize(IDirectSound *directSound, c
         return DSERR_INVALIDPARAM;
     }
 
-    static constexpr DWORD BadFlags{DSBCAPS_CTRLFX | DSBCAPS_CTRLPOSITIONNOTIFY
-        | DSBCAPS_LOCSOFTWARE};
+    static constexpr DWORD BadFlags{DSBCAPS_CTRLFX | DSBCAPS_CTRLPOSITIONNOTIFY};
     if((dsBufferDesc->dwFlags&BadFlags))
     {
         WARN("Bad dwFlags {:08x}", dsBufferDesc->dwFlags);
         return DSERR_INVALIDPARAM;
+    }
+
+    if((dsBufferDesc->dwFlags&DSBCAPS_LOCSOFTWARE)) {
+        WARN("Using DSBCAPS_LOCHARDWARE instead of DSBCAPS_LOCSOFTWARE");
     }
 
     std::lock_guard lock{mMutex};
@@ -323,7 +326,7 @@ HRESULT STDMETHODCALLTYPE PrimaryBuffer::Initialize(IDirectSound *directSound, c
             return hr;
     }
 
-    mFlags = dsBufferDesc->dwFlags | DSBCAPS_LOCHARDWARE;
+    mFlags = (dsBufferDesc->dwFlags & ~DSBCAPS_LOCSOFTWARE) | DSBCAPS_LOCHARDWARE;
 
     mImmediate.dwSize = sizeof(mImmediate);
     mImmediate.vPosition.x = 0.0f;


### PR DESCRIPTION
[The Void](https://store.steampowered.com/app/37000/The_Void/) errors out during startup because it's trying to create a primary buffer using DSBCAPS_LOCSOFTWARE. If that flag is simply stripped and ignored, the game will start and play back sound without any issues.

Here is the log for the current behavior on master: [TheVoid.log](https://github.com/user-attachments/files/22471570/TheVoid.log)

I'm not sure if this will work properly in every situation, but I'm expecting some games will simply assume DSBCAPS_LOCSOFTWARE is always supported, although DSBCAPS_LOCHARDWARE may not be.

Another alternative would be to simply allow it, but I assume there's a reason for it to have been filtered in the first place.