### PR TITLE
Silence x86-64 narrowing conversion warnings

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -830,7 +830,7 @@ HRESULT STDMETHODCALLTYPE Buffer::GetFormat(WAVEFORMATEX *wfx, DWORD sizeAllocat
         return DSERR_INVALIDPARAM;
     }
 
-    const DWORD size{sizeof(mBuffer->mWfxFormat.Format) + mBuffer->mWfxFormat.Format.cbSize};
+    const DWORD size{static_cast<DWORD>(sizeof(mBuffer->mWfxFormat.Format)) + mBuffer->mWfxFormat.Format.cbSize};
     if(sizeWritten)
         *sizeWritten = size;
     if(wfx)

--- a/src/dsoundoal.cpp
+++ b/src/dsoundoal.cpp
@@ -277,7 +277,7 @@ ds::expected<std::unique_ptr<SharedDevice>,HRESULT> CreateDeviceShare(const GUID
         return ds::unexpected(DSERR_OUTOFMEMORY);
     }
 
-    const DWORD maxHw{totalSources > MaxHwSources*2 ? MaxHwSources : (MaxHwSources/2)};
+    const DWORD maxHw{static_cast<DWORD>(totalSources > MaxHwSources*2 ? MaxHwSources : (MaxHwSources/2))};
 
     auto refresh = ALCint{20};
     alcGetIntegerv(aldev.get(), ALC_REFRESH, 1, &refresh);

--- a/src/primarybuffer.cpp
+++ b/src/primarybuffer.cpp
@@ -181,7 +181,7 @@ HRESULT STDMETHODCALLTYPE PrimaryBuffer::GetFormat(WAVEFORMATEX *wfx, DWORD size
     }
 
     std::lock_guard lock{mMutex};
-    const DWORD size{sizeof(mFormat.Format) + mFormat.Format.cbSize};
+    const DWORD size{static_cast<DWORD>(sizeof(mFormat.Format)) + mFormat.Format.cbSize};
     if(sizeWritten)
         *sizeWritten = size;
     if(wfx)


### PR DESCRIPTION
Silences some narrowing conversion warnings when compiling for x86-64 with MinGW e.g.:

```
/home/builder/source/dsoal-fork/src/buffer.cpp: In member function ‘virtual HRESULT Buffer::GetFormat(WAVEFORMATEX*, DWORD, DWORD*)’:
/home/builder/source/dsoal-fork/src/buffer.cpp:833:57: warning: narrowing conversion of ‘(sizeof (((Buffer*)this)->Buffer::mBuffer.ComPtr<SharedBuffer>::operator->()->SharedBuffer::mWfxFormat.WAVEFORMATEXTENSIBLE::Format) + ((long long unsigned int)((int)((Buffer*)this)->Buffer::mBuffer.ComPtr<SharedBuffer>::operator->()->SharedBuffer::mWfxFormat.WAVEFORMATEXTENSIBLE::Format.tWAVEFORMATEX::cbSize)))’ from ‘long long unsigned int’ to ‘DWORD’ {aka ‘long unsigned int’} [-Wnarrowing]
  833 |     const DWORD size{sizeof(mBuffer->mWfxFormat.Format) + mBuffer->mWfxFormat.Format.cbSize};
      |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I don't think any of them are ever expected to overflow a DWORD in any case, but let me know if it's something that should be considered.