### PR TITLE
Silence x86-64 conversion warnings

### DIFF
--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -809,8 +809,8 @@ HRESULT STDMETHODCALLTYPE Buffer::GetCurrentPosition(DWORD *playCursor, DWORD *w
      * Some testing should be done to see what happens. Wine always wraps the
      * play cursor, so just do that for now.
      */
-    pos %= mBuffer->mData.size();
-    writecursor %= mBuffer->mData.size();
+    pos %= ds::saturate_cast<DWORD>(mBuffer->mData.size());
+    writecursor %= ds::saturate_cast<DWORD>(mBuffer->mData.size());
 
     DEBUG(" pos = {}, write pos = {}", pos, writecursor);
 
@@ -1108,7 +1108,7 @@ HRESULT STDMETHODCALLTYPE Buffer::Play(DWORD reserved1, DWORD priority, DWORD fl
     if(state == AL_PLAYING)
         return DS_OK;
 
-    mLastPos %= mBuffer->mData.size();
+    mLastPos %= ds::saturate_cast<DWORD>(mBuffer->mData.size());
     if(state == AL_INITIAL)
     {
         alSourceiDirect(mContext, mSource, AL_BUFFER, static_cast<ALint>(mBuffer->mAlBuffer));

--- a/src/capture.cpp
+++ b/src/capture.cpp
@@ -270,7 +270,7 @@ HRESULT STDMETHODCALLTYPE DSCBuffer::GetCurrentPosition(LPDWORD lpdwCapturePosit
          * overwritten as new samples come in).
          */
         cappos += mWaveFmt.Format.nSamplesPerSec / 100 * mWaveFmt.Format.nBlockAlign;
-        cappos %= mBuffer.size();
+        cappos %= ds::saturate_cast<DWORD>(mBuffer.size());
     }
 
     DEBUG(" pos = {}, read pos = {}", cappos, readpos);

--- a/src/primarybuffer.cpp
+++ b/src/primarybuffer.cpp
@@ -17,7 +17,7 @@ using voidp = void*;
 using cvoidp = const void*;
 
 /* The primary buffer has a fixed size, apprently. */
-constexpr size_t PrimaryBufSize{32768};
+inline constexpr auto PrimaryBufSize = DWORD{32768};
 
 } // namespace
 


### PR DESCRIPTION
I'm afraid the the most recent commits have only shifted some size_t to DWORD related warnings around with x86-64 MinGW :sweat_smile::

```
/home/builder/source/dsoal-fork/src/buffer.cpp: In member function ‘virtual HRESULT Buffer::GetCurrentPosition(DWORD*, DWORD*)’:
/home/builder/source/dsoal-fork/src/buffer.cpp:812:32: warning: conversion from ‘std::span<char>::size_type’ {aka ‘long long unsigned int’} to ‘long unsigned int’ may change value [-Wconversion]
  812 |     pos %= mBuffer->mData.size();
```

I've addressed them with `ds::saturate_cast`, as I've seen is the preferred approach.

On a sidenote, something you might want to consider (not entirely sure if it is ever going to be a problem) is `ds::saturate_cast` behavior with float types, where you'd want `-std::numeric_limits<float>::max()` as a lower bounds check, rather than `std::numeric_limits<float>::min()` (which is really meant for precision checks).