### PR TITLE
Fix up return codes for enumeration calls

### DIFF
--- a/src/dsoal.cpp
+++ b/src/dsoal.cpp
@@ -641,6 +641,12 @@ HRESULT WINAPI DSOAL_DirectSoundEnumerateA(LPDSENUMCALLBACKA callback, void *use
 {
     TRACE("({}, {})", std::bit_cast<void*>(callback), userPtr);
 
+    if(!callback)
+    {
+        WARN("invalid parameter: callback == NULL");
+        return DSERR_INVALIDPARAM;
+    }
+
     auto do_enum = [=](GUID *const guid, std::wstring_view const dname,
         std::wstring_view const mname) -> bool
     {
@@ -670,7 +676,8 @@ HRESULT WINAPI DSOAL_DirectSoundEnumerateA(LPDSENUMCALLBACKA callback, void *use
     };
 
     auto const listlock = std::lock_guard{gDeviceListMutex};
-    return enumerate_mmdev(eRender, gPlaybackDevices, do_enum);
+    HRESULT hr{enumerate_mmdev(eRender, gPlaybackDevices, do_enum)};
+    return SUCCEEDED(hr) ? DS_OK : hr;
 }
 #undef PREFIX
 
@@ -679,11 +686,18 @@ HRESULT WINAPI DSOAL_DirectSoundEnumerateW(LPDSENUMCALLBACKW callback, void *use
 {
     TRACE("({}, {})", std::bit_cast<void*>(callback), userPtr);
 
+    if(!callback)
+    {
+        WARN("invalid parameter: callback == NULL");
+        return DSERR_INVALIDPARAM;
+    }
+
     auto do_enum = [callback,userPtr](GUID *guid, const WCHAR *dname, const WCHAR *mname)
     { return callback(guid, dname, mname, userPtr) != FALSE; };
 
     auto const listlock = std::lock_guard{gDeviceListMutex};
-    return enumerate_mmdev(eRender, gPlaybackDevices, do_enum);
+    HRESULT hr{enumerate_mmdev(eRender, gPlaybackDevices, do_enum)};
+    return SUCCEEDED(hr) ? DS_OK : hr;
 }
 #undef PREFIX
 
@@ -691,6 +705,12 @@ HRESULT WINAPI DSOAL_DirectSoundEnumerateW(LPDSENUMCALLBACKW callback, void *use
 HRESULT WINAPI DSOAL_DirectSoundCaptureEnumerateA(LPDSENUMCALLBACKA callback, void *userPtr) noexcept
 {
     TRACE("({}, {})", std::bit_cast<void*>(callback), userPtr);
+
+    if(!callback)
+    {
+        WARN("invalid parameter: callback == NULL");
+        return DSERR_INVALIDPARAM;
+    }
 
     auto do_enum = [=](GUID *const guid, std::wstring_view const dname,
         std::wstring_view const mname) -> bool
@@ -721,20 +741,28 @@ HRESULT WINAPI DSOAL_DirectSoundCaptureEnumerateA(LPDSENUMCALLBACKA callback, vo
     };
 
     auto const listlock = std::lock_guard{gDeviceListMutex};
-    return enumerate_mmdev(eCapture, gCaptureDevices, do_enum);
+    HRESULT hr{enumerate_mmdev(eCapture, gCaptureDevices, do_enum)};
+    return SUCCEEDED(hr) ? DS_OK : hr;
 }
 #undef PREFIX
 
-#define PREFIX "DirectSoundEnumerateW "
+#define PREFIX "DirectSoundCaptureEnumerateW "
 HRESULT WINAPI DSOAL_DirectSoundCaptureEnumerateW(LPDSENUMCALLBACKW callback, void *userPtr) noexcept
 {
     TRACE("({}, {})", std::bit_cast<void*>(callback), userPtr);
+
+    if(!callback)
+    {
+        WARN("invalid parameter: callback == NULL");
+        return DSERR_INVALIDPARAM;
+    }
 
     auto do_enum = [callback,userPtr](GUID *guid, const WCHAR *dname, const WCHAR *mname)
     { return callback(guid, dname, mname, userPtr) != FALSE; };
 
     auto const listlock = std::lock_guard{gDeviceListMutex};
-    return enumerate_mmdev(eCapture, gCaptureDevices, do_enum);
+    HRESULT hr{enumerate_mmdev(eCapture, gCaptureDevices, do_enum)};
+    return SUCCEEDED(hr) ? DS_OK : hr;
 }
 #undef PREFIX
 

--- a/src/enumerate.h
+++ b/src/enumerate.h
@@ -62,7 +62,7 @@ HRESULT enumerate_mmdev(const EDataFlow flow, std::deque<GUID> &devlist, T&& cb)
     std::deque<GUID>{}.swap(devlist);
 
     TRACE("Calling back with NULL ({})", wstr_to_utf8(std::data(primary_desc)));
-    auto keep_going = bool{cb(nullptr, primary_desc, L"")};
+    auto keep_going = static_cast<bool>(cb(nullptr, primary_desc, L""));
 
     auto send_device = [&devlist,&cb,&keep_going](IMMDevice *device)
     {


### PR DESCRIPTION
Fixes #130, possibly also #154 and #144.

Some games seem to be particularly sensitive about the return code of Enumerate calls, and based on official docs that is:

> Return Value
> 
> If the function succeeds, it returns DS_OK. If it fails, the return value may be DSERR_INVALIDPARAM. 

I'm not entirely sure why `enumerate_mmdev` returns based on the last value of `keep_going` since that, if I'm reading the code correctly, will always end up as false when the endpoint list is exhausted.

Part of this PR I've also:
- validated the callback, to avoid dereferencing a potentially null pointer (I doubt it happens in practice, but native dsound does validate it)
- statically cast the callback return to bool to avoid a "narrowing conversion" warning in mingw (HRESULT/INT to bool)