### PR TITLE
Add Windows script to run executable with logging

### DIFF
--- a/.github/workflows/Tagged.yaml
+++ b/.github/workflows/Tagged.yaml
@@ -143,6 +143,8 @@ jobs:
         mv "Release/Win64" "Release/DSOAL/Win64"
         mv "Release/DSOAL/Win32/Documentation" "Release/DSOAL/Documentation"
         rm -r "Release/DSOAL/Win64/Documentation"
+        curl https://raw.githubusercontent.com/kcat/openal-soft/master/logging/log.cmd -o "Release/DSOAL/Win32/log.cmd"
+        curl https://raw.githubusercontent.com/kcat/openal-soft/master/logging/log.cmd -o "Release/DSOAL/Win64/log.cmd"
         cp -R "Release/DSOAL" "Release/DSOAL+HRTF"
         mv "Release/DSOAL+HRTF/Win32/alsoft.ini" "Release/DSOAL+HRTF/Documentation/alsoft.ini"
         rm "Release/DSOAL+HRTF/Win64/alsoft.ini"

--- a/.github/workflows/Untagged.yaml
+++ b/.github/workflows/Untagged.yaml
@@ -138,6 +138,8 @@ jobs:
         mv "Release/Win64" "Release/DSOAL/Win64"
         mv "Release/DSOAL/Win32/Documentation" "Release/DSOAL/Documentation"
         rm -r "Release/DSOAL/Win64/Documentation"
+        curl https://raw.githubusercontent.com/kcat/openal-soft/master/logging/log.cmd -o "Release/DSOAL/Win32/log.cmd"
+        curl https://raw.githubusercontent.com/kcat/openal-soft/master/logging/log.cmd -o "Release/DSOAL/Win64/log.cmd"
         cp -R "Release/DSOAL" "Release/DSOAL+HRTF"
         mv "Release/DSOAL+HRTF/Win32/alsoft.ini" "Release/DSOAL+HRTF/Documentation/alsoft.ini"
         rm "Release/DSOAL+HRTF/Win64/alsoft.ini"


### PR DESCRIPTION
Equivalent of https://github.com/kcat/openal-soft/pull/1207
https://github.com/ThreeDeeJay/dsoal/releases/tag/latest-log
https://github.com/ThreeDeeJay/dsoal/releases/download/latest-log/DSOAL.7z
https://github.com/ThreeDeeJay/dsoal/releases/download/latest-log/DSOAL.zip

On a side note, should I also include [DSWRP](https://github.com/ThreeDeeJay/DSWRP) (in a different PR, of course)?
I think more people run into issues caused by Windows just not loading dsound.dll than stuff that needs looking at the log.
Though I'm not sure how to go about adding SetACL (I got explicit permission to redistribute it but it's a closed-source executable needed to take ownership of some system registry keys'). Like, I'd need to download and extract directly from the official site (or maybe a Web Archive backup to act as a commit-specific submodule).

Also, I'm not sure if there's some temporary outage/maintenance/bug, but the release page is empty unless we go into an individual release via Tags 🤔 
https://github.com/kcat/dsoal/releases
Tried a couple browsers and other people are also seeing an empty page.
Even in my fork, only a test and the release above are visible in page 1. Page 2 is completely empty though pages 3+ work.
https://github.com/ThreeDeeJay/dsoal/releases
Perhaps non-scheduled (manually triggered via commit push or workflow run) might restore them. 